### PR TITLE
fix(wzl): change [] to nn.ModuleList in MDDPG_Critic to avoid differe…

### DIFF
--- a/offpolicy/algorithms/maddpg/algorithm/actor_critic.py
+++ b/offpolicy/algorithms/maddpg/algorithm/actor_critic.py
@@ -64,7 +64,7 @@ class MADDPG_Critic(nn.Module):
         init_method = [nn.init.xavier_uniform_, nn.init.orthogonal_][self._use_orthogonal]
         def init_(m):
             return init(m, init_method, lambda x: nn.init.constant_(x, 0))
-        self.q_outs = [init_(nn.Linear(self.hidden_size, 1)) for _ in range(num_q_outs)]
+        self.q_outs = nn.ModuleList([init_(nn.Linear(self.hidden_size, 1)) for _ in range(num_q_outs)])
         
         self.to(device)
 


### PR DESCRIPTION
# command
`sh ./train_mpe_maddpg.sh`
# error
`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`
# reason
`self.q_outs = [init_(nn.Linear(self.hidden_size, 1)) for _ in range(num_q_outs)]`
`self.to(device)`
In this way, the `to(device)` won’t transfer these parameters to the desired device.
# ref
https://discuss.pytorch.org/t/is-it-mandatory-to-add-modules-to-modulelist-to-access-its-parameters/81622/7
